### PR TITLE
(CAT-1688) Upgrade rubocop to `~> 1.50.0`

### DIFF
--- a/pdk-rubocop.gemspec
+++ b/pdk-rubocop.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.files = Dir['lib/**/*.rb'] + ['module_rubocop.yml']
 
   spec.add_dependency 'rake'
-  spec.add_dependency 'rubocop', '= 1.48.1'
+  spec.add_dependency 'rubocop', '~> 1.50.0'
   spec.add_dependency 'rubocop-performance', '= 1.16.0'
   spec.add_dependency 'rubocop-rspec', '= 2.19.0'
 end


### PR DESCRIPTION
Following a recent team decision, we are implementing a Rubocop Upgrade, moving the version from 1.48.1 to 1.50.0. This should be the final version until Puppet 7 is unsupported.
