### PR TITLE
(CAT-1733) Remove Support for PDK-Rubocop

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,12 @@ PDK RuboCop is a Gem that provides sane defaults to use when developing Puppet C
 
 This gem was inspired by [voxpupuli-rubocop](https://github.com/voxpupuli/voxpupuli-rubocop)
 
+## Warning
+
+This tool has not seen proper usage yet as its [implementation PR]() has not been merged. We have no current plans
+to introduce it in the near future. This tool is no longer officially supported by the DevX team and will not receive
+any updated in the forseeable future. It will also be archived in the near future.
+
 ## Usage
 
 In your Gemfile, add the following:

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This gem was inspired by [voxpupuli-rubocop](https://github.com/voxpupuli/voxpup
 
 ## Warning
 
-This tool has not seen proper usage yet as its [implementation PR]() has not been merged. We have no current plans
+This tool has not seen proper usage yet as its [implementation PR](https://github.com/puppetlabs/pdk-templates/pull/511) has not been merged. We have no current plans
 to introduce it in the near future. This tool is no longer officially supported by the DevX team and will not receive
 any updated in the forseeable future. It will also be archived in the near future.
 


### PR DESCRIPTION
We have decided to remove support from pdk-rubocop as it is a tool that has not seen proper implementation yet, nor do we have current plans to make use of it.

This commit addressed the README file of the tool to inform users of its new status, as well as announcing its future deprecation.
